### PR TITLE
freeze Let's Go button, fix z-indexing for navbar

### DIFF
--- a/src/components/AdvancedSearch.tsx
+++ b/src/components/AdvancedSearch.tsx
@@ -76,7 +76,7 @@ export const AdvancedSearch = (props: AdvancedSearchProps) => {
   return (
     <>
       {
-        <Accordion alwaysOpen={true}>
+        <Accordion alwaysOpen={true} style={{ paddingBottom: "8.5em" }}>
           {Object.entries(valueDictionary).map((entry, catID) => {
             return (
               <div key={catID} className="mx-4 mb-2">

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -10,6 +10,7 @@ export const NavBar: React.FC = () => {
         overflow: "auto",
         bottom: "0",
         width: "100%",
+        zIndex: 3,
       }}
       bg="dark"
     >

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -47,10 +47,20 @@ export const SearchPage: React.FC<SearchPageProps> = ({
           setFilterValues={setFilterValues}
         />
       }
-      <div className="text-center mt-3 mb-5">
+      <div
+        className="text-center mt-3 mb-5"
+        style={{
+          position: "fixed",
+          bottom: 5,
+          width: "100%",
+          background: "#ffffff",
+          zIndex: 3,
+        }}
+      >
         <Button
           className="mb-3"
           variant="secondary"
+          style={{ margin: "1em" }}
           size="lg"
           active
           onClick={() => {


### PR DESCRIPTION
- adjusted the css for the let's go button and its div container (now frozen above the navbar)
- also fixed a UI bug where hovering over an accordion header had a higher z-index than the navbar (see image below)
<img width="500" alt="Screen Shot 2022-05-28 at 2 59 40 PM" src="https://user-images.githubusercontent.com/61598475/170842008-27c202c1-27f0-48f0-b721-0630df849109.png">
 