### PR TITLE
BUGFIX: placeholder image producing fetch errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import "bootstrap/dist/css/bootstrap.min.css";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import "./App.css";
 import { NavBar } from "./components/NavBar";
@@ -7,8 +7,6 @@ import { Results } from "./pages/Results";
 import { SearchPage } from "./pages/SearchPage";
 import { BusinessEntry } from "./types/BusinessTypes";
 import { useData } from "./utilities/firebase";
-import { setThumbnailImages } from "./utilities/images";
-import { filterBusinesses } from "./utilities/filtering";
 
 const App = () => {
   // state variables
@@ -19,13 +17,6 @@ const App = () => {
   const [advancedFilterValues, setAdvancedFilterValues] = useState<string[]>(
     [] as string[]
   );
-
-  // generating thumbnails for each business
-  useEffect(() => {
-    setThumbnailImages(loadingBusinesses, businessData, setBusinessData).then(
-      () => console.log("businesses thumbnail updated")
-    );
-  }, [loadingBusinesses]);
 
   // returned page
   return (

--- a/src/utilities/images.ts
+++ b/src/utilities/images.ts
@@ -1,10 +1,13 @@
 import { BusinessEntry } from "../types/BusinessTypes";
-
 export const getImage = async (width: number, height: number) => {
   const srcURL = `https://picsum.photos/${width}/${height}`;
   const response = await fetch(srcURL);
   const imgBlob = await response.blob();
-  return URL.createObjectURL(imgBlob);
+  const reader = new FileReader();
+  return new Promise<string>((resolve, reject) => {
+    reader.onloadend = (_e) => resolve(reader.result as string);
+    reader.readAsDataURL(imgBlob);
+  });
 };
 
 export const getImageArray = async (


### PR DESCRIPTION
- set the thumbnail field in each business in the real-time database to be a data-url

effects:
- console logs for missing placeholder data removed
- no longer making get requests to fetch images from picsum, (no more wait time).